### PR TITLE
Update hterm-show-file.sh

### DIFF
--- a/hterm/etc/hterm-show-file.sh
+++ b/hterm/etc/hterm-show-file.sh
@@ -27,23 +27,21 @@ screen_dcs() {
 print_seq() {
   local seq="$1"
 
-  case ${TERM-} in
-  screen*)
-    # Since tmux defaults to setting TERM=screen (ugh), we need to detect
-    # it here specially.
-    if [ -n "${TMUX-}" ]; then
-      tmux_dcs "${seq}"
-    else
-      screen_dcs "${seq}"
-    fi
-    ;;
-  tmux*)
+  if [ -n "${TMUX-}" ]; then
     tmux_dcs "${seq}"
-    ;;
-  *)
-    echo "${seq}"
-    ;;
-  esac
+  else
+    case ${TERM-} in
+    screen*)
+      screen_dcs "${seq}"
+      ;;
+    tmux*)
+      tmux_dcs "${seq}"
+      ;;
+    *)
+      echo "${seq}"
+      ;;
+    esac
+  fi
 }
 
 # Base64 encode stdin.


### PR DESCRIPTION
Many Tmux users will change TERM to something else, so it's not a reliable way to detect Tmux. However using the `TMUX` environment variable is quite reliable.